### PR TITLE
Should not set `required: true` with default variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,6 @@ branding:
 inputs:
   version:
     description: 'The version of buf to setup.'
-    required: true
     default: 'latest'
 runs:
   using: 'node12'


### PR DESCRIPTION
This is a small clean-up PR. We should not be setting `required: true` on inputs that have defaults.
On the flip side, we should still keep the input validation at run time, in case of situations
where users have set `version: ''`.﻿
