### PR TITLE
Revert "Add dependabot config (#21)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This reverts commit e789cb128b4b65cd90baa6578eb693c641b68698.

Dependabot needs some cla updates and is appearently bumping major versions. Going to revert until we have a need to update and resolve that rather than having it open in a half working state.