### PR TITLE
TCN-875 Resolve sync v1 branch bug

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           git fetch origin
           git switch v1
-          git merge main
+          git merge origin/main
           git push origin v1
       - name: Release
         id: ghr


### PR DESCRIPTION
The last release [failed to sync the v1 branch](https://github.com/bufbuild/buf-setup-action/actions/runs/3758482157/jobs/6386878631) with main and required manual intervention. I have fixed this bug on a branch and tested [here](https://github.com/elliotmjackson/buf-setup-action/actions/runs/3758581064/jobs/6387090474)