### PR TITLE
Add token to checkout action

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -30,6 +30,8 @@ jobs:
           private-key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
       - name: Checkout repository code
         uses: actions/checkout@v3
+        with:
+          token: ${{ steps.app_token.outputs.token }}
       - uses: actions/setup-go@v3
         with:
           go-version: '^1.19.x'


### PR DESCRIPTION
This fixes permission for `git push` by providing a token in checkout action