### PR TITLE
Correct buf CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can configure `buf-setup-action` with these parameters:
 
 | Parameter      | Description                                        | Default            |
 |:---------------|:---------------------------------------------------|:-------------------|
-| `version`      | The version of the [`buf` CLI][buf-cli] to install | [`v1.29.0-1`][version] |
+| `version`      | The version of the [`buf` CLI][buf-cli] to install | [`v1.29.0`][version] |
 | `github_token` | The GitHub token to use when making API requests   |                    |
 | `buf_user`     | The username to use for logging into Buf Schema registry.                                               |                    |
 | `buf_api_token` | The API token to use for logging into Buf Schema registry.                                                                                                            |                    |
@@ -59,8 +59,8 @@ steps:
   # Installs version 1.29.0-1
   - uses: bufbuild/buf-setup-action@v1.29.0-1
     with:
-      version: 1.29.0-1
-  # Should output 1.29.0-1
+      version: 1.29.0
+  # Should output 1.29.0
   - run: buf --version
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: The version of buf to set up.
     required: false
-    default: '1.29.0-1'
+    default: '1.29.0'
   github_token:
     description: The GitHub token to use when making API requests.
     required: false


### PR DESCRIPTION
Release 1.29.0-1 used the wrong version for the CLI. Fixes the action.

Fixes #188