### PR TITLE
Check action bundles buf correctly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,6 @@ jobs:
         run: make generate && make checkgenerate
       - name: Build
         run: make build && make checkgenerate
+      - name: Validate Action
+        uses: bufbuild/buf-setup-action@${{ github.sha }}
+      - run: buf --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,5 @@ jobs:
       - name: Build
         run: make build && make checkgenerate
       - name: Validate Action
-        uses: bufbuild/buf-setup-action@${{ github.sha }}
+        uses: ./
       - run: buf --version


### PR DESCRIPTION
This PR ensures CI runs the action built from this commit. We output the buf version from the given action to check the buf cli is successfully fetched.