### PR TITLE
Link to buf-action migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This action has been deprecated in favor of the [`buf-action`][buf-action] which combines the
 > functionality of `buf-setup-action` with the ability to run Buf commands in the same step. Please
-> see the [migration guide][buf-action-migrtion] documentation for more information.
+> see the [migration guide][buf-action-migration] documentation for more information.
 
 This [Action] installs the [`buf`][buf-cli] CLI in your GitHub Actions pipelines so that it can be
 used by other Buf Actions:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This action has been deprecated in favor of the [`buf-action`][buf-action] which combines the
 > functionality of `buf-setup-action` with the ability to run Buf commands in the same step. Please
-> see the [`buf-action`][buf-action] documentation for more information.
+> see the [migration guide][buf-action-migrtion] documentation for more information.
 
 This [Action] installs the [`buf`][buf-cli] CLI in your GitHub Actions pipelines so that it can be
 used by other Buf Actions:
@@ -175,6 +175,7 @@ steps:
 
 [action]: https://docs.github.com/actions
 [buf-action]: https://github.com/bufbuild/buf-action
+[buf-action-migration]: https://github.com/bufbuild/buf-action/blob/main/MIGRATION.md#buf-setup-action
 [breaking]: https://docs.buf.build/breaking
 [bsr]: https://docs.buf.build/bsr
 [buf-breaking]: https://github.com/marketplace/actions/buf-breaking

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This action has been deprecated in favor of the [`buf-action`][buf-action] which combines the
 > functionality of `buf-setup-action` with the ability to run Buf commands in the same step. Please
-> see the [migration guide][buf-action-migration] documentation for more information.
+> see the [migration guide][buf-action-migration] for more information.
 
 This [Action] installs the [`buf`][buf-cli] CLI in your GitHub Actions pipelines so that it can be
 used by other Buf Actions:


### PR DESCRIPTION
This updates the deprecation message to link to the buf-action migration guide.